### PR TITLE
Add delete to allow clearing failed torrents

### DIFF
--- a/betanin/api/jobs/import_torrents.py
+++ b/betanin/api/jobs/import_torrents.py
@@ -64,6 +64,21 @@ def add(**kwargs):
     events.torrents_changed()
 
 
+def remove(**kwargs):
+    torrent = Torrent(**kwargs)
+    # dont store lines that dont have an associated torrent
+    db.session.execute(
+        'DELETE FROM lines WHERE id = :id',
+        {'id': torrent.id})
+    # delete the actual torrent second in case of foreign key
+    db.session.execute(
+        'DELETE FROM torrents WHERE id = :id',
+        {'id': torrent.id})
+    db.session.commit()
+    # send a howdy to the client
+    events.torrents_changed()
+
+
 def start():
     while True:
         torrent_id = QUEUE.get()

--- a/betanin/api/rest/resources/torrents.py
+++ b/betanin/api/rest/resources/torrents.py
@@ -32,6 +32,15 @@ class TorrentsResource(BaseResource):
             name=content['name'],
         )
 
+    @staticmethod
+    @torrents_ns.expect(request_models.torrent)
+    def delete():
+        content = request.form
+        import_torrents.remove(
+            id=content['id'],
+            path=content['path'],
+            name=content['name']
+        )
 
 @torrents_ns.route('/<string:torrent_id>/console/stdout')
 class StdoutResource(BaseResource):


### PR DESCRIPTION
:cowboy_hat_face: hello this might be nice to have so you can remove failed torrents or torrents you no longer care about from history.

I have no idea how to add a button to let you actually use this endpoint

Will add another pr for retrying a torrent