### PR TITLE
Make it more apparent that you can open the console

### DIFF
--- a/betanin/client/src/components/Downloads.vue
+++ b/betanin/client/src/components/Downloads.vue
@@ -117,4 +117,7 @@ export default {
   #row-status {
     text-align: right;
   }
+  #console-link {
+    cursor: pointer;
+  }
 </style>


### PR DESCRIPTION
it ain't very obvious you can click on this shit, maybe even use 
`cursor: default`
if you don't like the pointing man