### PR TITLE
Remove `--copy` flag from `beet import` command

### DIFF
--- a/betanin/jobs/import_torrents.py
+++ b/betanin/jobs/import_torrents.py
@@ -59,7 +59,6 @@ def _import_torrent(torrent):
         [
             "beet",
             "import",
-            "--copy",
             "--noresume",
             _calculate_import_path(torrent),
         ]


### PR DESCRIPTION
Specifying `--copy` in the command overrides the corresponding setting
in the user's `config.yaml`. The flag should be omitted so `copy` or
`move` behavior can be configured within `config.yaml`.

The `--noresume` flag should remain because, by nature of Betanin's
purpose, no imports should be resumed.