### PR TITLE
Resolves #39: Parallel import

### DIFF
--- a/betanin/config/betanin.py
+++ b/betanin/config/betanin.py
@@ -22,6 +22,7 @@ _DEFAULT_CONFIG = {
         },
     },
     "clients": {"api_key": ""},
+    "server": {"num_parallel_jobs": 1},
 }
 _NEEDED_CONFIG_PATHS = (
     # (path, ) reason
@@ -83,6 +84,10 @@ def api_key_correct(api_key):
 
 def get_api_key():
     return read()["clients"]["api_key"]
+
+
+def get_num_parallel_jobs():
+    return read().get("server", {}).get("num_parallel_jobs", 1)
 
 
 def ensure():

--- a/betanin/entry/betanin.py
+++ b/betanin/entry/betanin.py
@@ -75,8 +75,8 @@ def main(host, port):
     gevent.joinall(
         (
             start_job(register_notifications),
-            start_job(import_torrents),
             start_job(serve_web, host, port),
+            start_job(import_torrents),
         )
     )
 

--- a/betanin/jobs/import_torrents.py
+++ b/betanin/jobs/import_torrents.py
@@ -8,6 +8,7 @@ from ptyprocess import PtyProcessUnicode
 from gevent.queue import Queue
 
 # betanin
+import betanin.config.betanin as conf_betanin
 from betanin import events
 from betanin import notifications
 from betanin.models import Line
@@ -130,4 +131,11 @@ def start(flask_app):
         with flask_app.app_context():
             _start()
 
-    return gevent.spawn(with_context)
+    #return gevent.spawn(with_context)
+
+    num_parallel_jobs = conf_betanin.get_num_parallel_jobs()
+    return gevent.joinall(
+        [
+            gevent.spawn(with_context) for _ in range(num_parallel_jobs)
+        ]
+    )


### PR DESCRIPTION
Resolves #39 
This adds support for parallel import.
It's based on the code you provided in #39. I put the new option `num_parallel_jobs` is in the new `[server]` section because just appending it to the config would mean it's inside the `[notification.strings]` section.

Tested it with a bunch of imports and seems to work so far.