### PR TITLE
chore(deps): bump Unidecode to version 1.3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ REQUIREMENTS = [
     "toml==0.10.2",
     "typing-extensions==3.10.0.0",
     "tzlocal==2.1",
-    "Unidecode==1.1.2",
+    "Unidecode>=1.3.6",
     "urllib3==1.26.2",
     "Werkzeug==0.16.1",
     "zipp==3.4.0",


### PR DESCRIPTION
Hi,
Install failed since this commit https://github.com/beetbox/beets/commit/5ae1e0f3c8d3a450cb39f7933aa49bb78c2bc0d9 on the beets repository if you build beets from source like on my Dockerfile https://github.com/jee-r/docker-beets/blob/3b9706e7e3d982daa40818c11ef3bd5b728b3d41/Dockerfile#L112

Minimum Unidecode version is 1.3.6 for beets  https://github.com/beetbox/beets/blob/c8ab0cfa6b5babf3b2b32a7a77a0303530e888a6/setup.py#L88

i'm really new to python i don't know how you manage dependencies, let me know if i'm doing it wrong.