### PR TITLE
Added support for optional extra beets plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN npm install && \
 FROM alpine:3.18 AS builder-mp3gain
 WORKDIR /tmp
 COPY alpine/mp3gain/APKBUILD .
-RUN apk update && \
+RUN mkdir -p /tmp/out && \
+    apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
     cp /root/.abuild/*.rsa.pub /etc/apk/keys/ && \
@@ -18,7 +19,8 @@ RUN apk update && \
 FROM alpine:3.18 AS builder-mp3val
 WORKDIR /tmp
 COPY alpine/mp3val/APKBUILD .
-RUN apk update && \
+RUN mkdir -p /tmp/out && \
+    apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
     cp /root/.abuild/*.rsa.pub /etc/apk/keys/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY alpine/mp3gain/APKBUILD .
 RUN apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
+    cp /root/.abuild/*.rsa.pub /etc/apk/keys/ && \
     REPODEST=/tmp/out abuild -F -r
 
 
@@ -20,6 +21,7 @@ COPY alpine/mp3val/APKBUILD .
 RUN apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
+    cp /root/.abuild/*.rsa.pub /etc/apk/keys/ && \
     REPODEST=/tmp/out abuild -F -r
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV UID=1000
 ENV GID=1000
 
 RUN apk add --no-cache --upgrade --virtual=build-dependencies build-base cmake libffi-dev openssl-dev python3-dev jpeg-dev libpng-dev zlib-dev jpeg-dev cargo llvm14-dev openblas openblas-dev && \
-    apk add --no-cache --upgrade sudo python3 py-pip libev chromaprint ffmpeg gstreamer flac keyfinder-cli libsndfile && \
+    apk add --no-cache --upgrade python3 py-pip libev chromaprint ffmpeg gstreamer flac keyfinder-cli libsndfile && \
     apk add --no-cache --allow-untrusted /pkgs/* && \
     env LLVM_CONFIG="$(which llvm14-config)" pip install --no-cache-dir . --requirement requirements-docker.txt  && \
     apk del --purge build-dependencies && \
@@ -52,5 +52,7 @@ VOLUME /b/.config/beets/
 ENV HOME=/b
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONWARNINGS="ignore:Unverified HTTPS request"
+ENV PIP_EXTRA_PACKAGES=''
+ENV EXTRA_COMMAND=''
 
 ENTRYPOINT [ "/src/docker-entry" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /tmp/out && \
 
 
 FROM alpine:3.18
-LABEL org.opencontainers.image.source https://github.com/sentriz/betanin
+LABEL org.opencontainers.image.source=https://github.com/sentriz/betanin
 WORKDIR /src
 COPY . .
 COPY --from=builder-frontend /src/dist/ /src/betanin_client/dist/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ betanin:
   environment:
     - UID=1000 # (optionally) set user id
     - GID=1000 # (optionally) set group id
+    - PIP_EXTRA_PACKAGES=beetstream # (optional) comma separated values of additional plugins to install
+    - EXTRA_COMMANDS="beet beetstream &" # (optional) extra commands to run at start (note the `&` at the end to run it in the background)
   volumes:
     - ${DATA}/betanin/data:/b/.local/share/betanin/
     - ${DATA}/betanin/config:/b/.config/betanin/

--- a/docker-entry
+++ b/docker-entry
@@ -16,8 +16,40 @@ echo "!! https://github.com/sentriz/betanin"
 echo "!!"
 echo "!! thanks!"
 
-[ "$UID" -eq 0 ] && exec betanin
+if [ "$(id -u)" -eq 0 ]; then
+    # Running as root: install additional plugins
+    if [ -n "$PIP_EXTRA_PACKAGES" ]; then
+        echo "Installing additional pip packages: $PIP_EXTRA_PACKAGES"
+        pip install $(echo "$PIP_EXTRA_PACKAGES" | tr ',' ' ')
+        echo "Finished installing additional pip packages."
+    fi
 
-adduser -D -h "$HOME" -u "$UID" -g "$GID" betanin 2>/dev/null
-chown -R betanin:betanin "$HOME"
-exec sudo -u betanin -g betanin betanin
+    # and drop to an unpriviledged user
+    CURRENT_UID=${UID:-1000}
+    CURRENT_GID=${GID:-1000}
+
+    adduser -D -h "$HOME" -u "$UID" -g "$GID" betanin 2>/dev/null
+    chown -R betanin:betanin "$HOME"
+    echo "Switching to betanin user (UID: $CURRENT_UID, GID: $CURRENT_GID)"
+    exec su betanin -c "/bin/sh -c '$0'"
+else
+    # Not running as root: warn about unsupported features
+    echo " "
+    echo " "
+    echo "/!\ WARNING: Running this container using docker's `user` feature comes with some caveats:"
+    echo "- You need to have the proper volumes mounted, with the right permissions"
+    echo "- You won't be able to use additional plugins (they need to be installed by root for beets to see them)"
+    echo " "
+    echo " "
+fi
+
+if [ -n "$EXTRA_COMMANDS" ]; then
+    echo "Launching extra commands: $EXTRA_COMMANDS"
+    echo "$EXTRA_COMMANDS" | awk -v RS=',' '{print}' | while read -r cmd; do
+        if [ -n "$cmd" ]; then
+            sh -c "$cmd"
+        fi
+    done
+fi
+
+exec betanin

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -11,4 +11,4 @@ pillow
 unidecode
 jsonpath-rw
 pyyaml
-beets-bpmanalyser @ https://github.com/adamjakab/BeetsPluginBpmAnalyser/archive/devel.zip
+beets-bpmanalyser @ https://github.com/adamjakab/BeetsPluginBpmAnalyser/archive/refs/heads/master.zip


### PR DESCRIPTION
I'm using https://github.com/BinaryBrain/Beetstream to serve my beets database to Subsonic clients and wanted to have a clean way to install it.

So here are two new environment variables:

`PIP_EXTRA_PACKAGES` : comma separated list of beets plugins to install via pip
`EXTRA_COMMANDS` : comma separated list of extra commands to run at the start

Example given in the README:

```
(...)
environment:
    - UID=1000 # (optionally) set user id
    - GID=1000 # (optionally) set group id
    - PIP_EXTRA_PACKAGES=beetstream
    - EXTRA_COMMANDS="beet beetstream &"
( ...)
```

The pip install runs via root (because the plugins need to be installed in `/usr/lib/python3.11/site-packages` otherwise beets won't see them, but the root account is immediately dropped after that and then the extra commands and the main betanin command are ran under the unproviledged user.