### PR TITLE
fix: copy sign keys and change dependency branch to repair build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY alpine/mp3gain/APKBUILD .
 RUN apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
+    cp /root/.abuild/*.pub /etc/apk/keys/ && \
     REPODEST=/tmp/out abuild -F -r
 
 
@@ -20,6 +21,7 @@ COPY alpine/mp3val/APKBUILD .
 RUN apk update && \
     apk add --no-cache abuild && \
     abuild-keygen -a -n && \
+    cp /root/.abuild/*.pub /etc/apk/keys/ && \
     REPODEST=/tmp/out abuild -F -r
 
 

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -11,4 +11,4 @@ pillow
 unidecode
 jsonpath-rw
 pyyaml
-beets-bpmanalyser @ https://github.com/adamjakab/BeetsPluginBpmAnalyser/archive/devel.zip
+beets-bpmanalyser @ https://github.com/adamjakab/BeetsPluginBpmAnalyser/archive/master.zip


### PR DESCRIPTION
In the Dockerfile, added lines copying over the generated keys during build to specific directory to avoid errors during build. Also changed a dependency's branch because the previously used branch no longer exists.

I made this fix so I could use the newer beets version with support for multiple artists (ARTISTS tag) by rebuilding the docker image.